### PR TITLE
US-4

### DIFF
--- a/maquina-expendedora/src/Components/VendingMachine/VendingMachine.js
+++ b/maquina-expendedora/src/Components/VendingMachine/VendingMachine.js
@@ -37,18 +37,18 @@ export const VendingMachine = () => {
       `,
       icon: 'success',
       confirmButtonColor: '#27742D',
-      allowEnterKey: false,
+      allowEnterKey: true,
       allowOutsideClick: false,
       allowEscapeKey: false
     }).then((result) => {
       if (result.isConfirmed) {
-        updateMachineStock(order, stock, setStock);
-        setOrder([]);
-        updateClientMoney(clientMoney, setClientMoney);
-        updateCoinsStock(itemizedChange, coinsStock, setCoinsStock)
-        setCanPay(false);
+        updateCoinsStock(itemizedChange, coinsStock, setCoinsStock);
       }
     });
+    updateMachineStock(order, stock, setStock);
+    setOrder([]);
+    updateClientMoney(clientMoney, setClientMoney);
+    setCanPay(false);
   }
 
   const declinePayment = () => {


### PR DESCRIPTION
Corregido un error que hacía que el mensaje de fuera de servicio apareciera antes que el mensaje de pago completado una vez que la máquina se quedaba sin monedas